### PR TITLE
Change take_screenshots password and add user

### DIFF
--- a/tests/take_screenshots.spec.ts
+++ b/tests/take_screenshots.spec.ts
@@ -65,10 +65,17 @@ test.describe("The Installer", () => {
         await page.screenshot({ path: "screenshots/users-page.png" });
         // click on the "Set a password" button
         await page.getByRole("button", { name: "Set a password" }).click();
-        await page.locator("#password").fill("linux");
-        await page.locator("#passwordConfirmation").fill("linux");
+        await page.locator("#password").fill("nots3cr3t");
+        await page.locator("#passwordConfirmation").fill("nots3cr3t");
         await page.locator('button[type="submit"]').click();
-        await page.getByText("Back").click();
+	// click on the "Define a user now" button
+        await page.getByRole("button", { name: "Define a user now" }).click();
+        await page.locator("#userFullName").fill("Bernhard M. Wiedemann");
+        await page.locator("#userName").fill("bernhard");
+        await page.locator("#password").fill("nots3cr3t");
+        await page.locator("#passwordConfirmation").fill("nots3cr3t");
+        await page.locator('button[type="submit"]').click();
+	await page.getByText("Back").click();
       });
     }
 


### PR DESCRIPTION
After the agama_tumbleweed test decided to run the agama_base post_run_hook, it fails because of wrong root password and missing used "bernhard". This PR attempts to fix this issue
See failure: https://openqa.opensuse.org/tests/3458170#step/agama_installation/15
VR: https://openqa.opensuse.org/tests/3482079

Edited YUPDATE_GIT: sofiasyria/e2e-agama-playwright#too_fast in the openqa job group for now, as Joaquin who can merge is on vacation. This needs to be changed back to YUPDATE_GIT: jknphy/e2e-agama-playwright#main once merged.