### PR TITLE
Fix select device timeout issue

### DIFF
--- a/tests/select-install-device.spec.ts
+++ b/tests/select-install-device.spec.ts
@@ -20,6 +20,8 @@ test.describe('The main page', () => {
         const mainPage = new MainPage(page);
         await test.step("select second available device for installation", async () => {
             const storagePage = new StoragePage(page);
+            // Poo#137537 Workaround the device selection timeout issue.
+            await expect(page.getByText("Installation will take")).toBeVisible({ timeout: 2 * minute });
             const installationDevice = new InstallationDevicePage(page);
 
             await mainPage.accessStorage();


### PR DESCRIPTION
We need wait installation size shown in main page, then access storage page to select device.

Related ticket: https://progress.opensuse.org/issues/137537
VRs:  https://openqa.opensuse.org/tests/overview?version=agama-3.0-staging&build=lemon-suse%2Fos-autoinst-distri-opensuse%23master_for_clone_ref&distri=alp&flavor=agama-live-openSUSE-Playwright