### PR TITLE
Fix product selection issue

### DIFF
--- a/actors/index-actor.ts
+++ b/actors/index-actor.ts
@@ -27,7 +27,7 @@ export class IndexActor {
     // check for multiple texts in parallel, avoid waiting for timeouts
     let action = await Promise.any([
       this.productSelectionOpensusePage.productSelectionText.waitFor().then(() => actions.setProduct),
-      this.mainPage.installButton.waitFor().then(() => actions.setInstall),
+      this.mainPage.noUserDefined.waitFor().then(() => actions.setInstall),
     ]);
 
     // optional product selection

--- a/pages/main-page.ts
+++ b/pages/main-page.ts
@@ -5,12 +5,16 @@ export class MainPage {
     readonly accessStorageLink: Locator;
     readonly accessUsersLink: Locator;
     readonly installButton: Locator;
+    readonly installationSize: Locator;
+    readonly noUserDefined: Locator;
 
     constructor(page: Page) {
         this.page = page;
         this.accessStorageLink = page.getByRole('link', { name: 'Storage' });
         this.accessUsersLink = page.getByRole('link', { name: 'Users' });
         this.installButton = page.getByRole("button", { name: "Install", exact: true });
+        this.installationSize = page.getByText("Installation will take");
+        this.noUserDefined = page.getByText('No user defined yet');
     }
 
     async accessStorage() {
@@ -19,6 +23,10 @@ export class MainPage {
 
     async accessUsers() {
         await this.accessUsersLink.click();
+    }
+
+    async expectInstallationSize() {
+        await expect(this.installationSize).toBeVisible({ timeout: 2 * 60 * 1000 });
     }
 
     async install() {

--- a/tests/add-home-file-system.spec.ts
+++ b/tests/add-home-file-system.spec.ts
@@ -19,6 +19,7 @@ test.describe('The main page', () => {
 
     test('Add /home file system', async ({ page }) => {
         const mainPage = new MainPage(page);
+        await mainPage.expectInstallationSize();
         await test.step("Start to add home file system", async () => {
             await mainPage.accessStorage();
 

--- a/tests/encrypted_lvm.spec.ts
+++ b/tests/encrypted_lvm.spec.ts
@@ -19,6 +19,7 @@ test.describe('The main page', () => {
 
     test('Installation test with encrypted lvm file system', async ({ page }) => {
         const mainPage = new MainPage(page);
+        await mainPage.expectInstallationSize();
         await test.step("set encrypted lvm file system", async () => {
             await mainPage.accessStorage();
 

--- a/tests/full-disk-encryption.spec.ts
+++ b/tests/full-disk-encryption.spec.ts
@@ -19,6 +19,7 @@ test.describe('The main page', () => {
 
     test('Full-disk encryption', async ({ page }) => {
         const mainPage = new MainPage(page);
+        await mainPage.expectInstallationSize();
         await test.step("Set for Full-disk encryption", async () => {
             await mainPage.accessStorage();
 

--- a/tests/lvm.spec.ts
+++ b/tests/lvm.spec.ts
@@ -18,6 +18,7 @@ test.describe('The main page', () => {
 
     test("Use logical volume management (LVM) as storage device for installation", async ({ page }) => {
         const mainPage = new MainPage(page);
+        await mainPage.expectInstallationSize();
         await test.step("Set LVM and Users", async () => {
             await mainPage.accessStorage();
 

--- a/tests/select-install-device.spec.ts
+++ b/tests/select-install-device.spec.ts
@@ -19,10 +19,9 @@ test.describe('The main page', () => {
 
     test('Installation on second available storage device', async ({ page }) => {
         const mainPage = new MainPage(page);
+        await mainPage.expectInstallationSize();
         await test.step("select second available device for installation", async () => {
             const storagePage = new StoragePage(page);
-            // Poo#137537 Workaround the device selection timeout issue.
-            await expect(page.getByText("Installation will take")).toBeVisible({ timeout: 2 * minute });
             const installationDevice = new InstallationDevicePage(page);
 
             await mainPage.accessStorage();


### PR DESCRIPTION
The index-actor which judge the current test is for main page of dolomite or product selection page via text of product selection or install button, while on the new build when installation starts the main page will  be shown before product selection page. So I change the condition of install button to a text 'No user defined yet', then the previous production selection issue fixed. 
Besides, wait the size calculation ready then enter storage page to solve the performance issue.

Failed Jobs: https://openqa.opensuse.org/tests/overview?result=failed&result=incomplete&result=timeout_exceeded&distri=alp&version=agama-4.0-staging&build=3.3&groupid=96
Related ticket:
https://progress.opensuse.org/issues/138557
VRs:
https://openqa.opensuse.org/tests/3673257#
https://openqa.opensuse.org/tests/3673285#details
https://openqa.opensuse.org/tests/3673286#
https://openqa.opensuse.org/tests/3676830#
https://openqa.opensuse.org/tests/3676835#
https://openqa.opensuse.org/tests/3676837#