### PR TITLE
WIP Add a test to select patterns

### DIFF
--- a/pages/main-page.ts
+++ b/pages/main-page.ts
@@ -2,6 +2,7 @@ import { expect, type Locator, type Page } from '@playwright/test';
 
 export class MainPage {
     readonly page: Page;
+    readonly accessSoftwareLink: Locator;
     readonly accessStorageLink: Locator;
     readonly accessUsersLink: Locator;
     readonly installButton: Locator;
@@ -10,11 +11,16 @@ export class MainPage {
 
     constructor(page: Page) {
         this.page = page;
+        this.accessSoftwareLink = page.getByRole('link', { name: 'Software' });
         this.accessStorageLink = page.getByRole('link', { name: 'Storage' });
         this.accessUsersLink = page.getByRole('link', { name: 'Users' });
         this.installButton = page.getByRole("button", { name: "Install", exact: true });
         this.installationSize = page.getByText("Installation will take");
         this.noUserDefined = page.getByText('No user defined yet');
+    }
+
+    async accessSoftware() {
+        await this.accessSoftwareLink.click();
     }
 
     async accessStorage() {

--- a/pages/patterns-page.ts
+++ b/pages/patterns-page.ts
@@ -1,0 +1,31 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+export class PatternsPage {
+    readonly page: Page;
+    readonly yastDesktopUtilitiesLabel: Locator;
+    readonly gnomeDesktopBasicLabel: Locator;
+    readonly enhancedBaseSystemLabel: Locator;
+    readonly backButton: Locator;
+
+    constructor(page: Page) {
+        this.page = page;
+        this.yastDesktopUtilitiesLabel = page.getByText('YaST Desktop Utilities');
+        this.gnomeDesktopBasicLabel = page.getByText('GNOME Desktop Environment (Basic)');
+        this.enhancedBaseSystemLabel = page.getByText('Enhanced Base System');
+        this.backButton = page.getByRole('button', { name: 'Back' });
+    }
+
+    async selectPatterns() {
+        await expect(this.yastDesktopUtilitiesLabel).toBeVisible({ timeout: 30000 });
+        await this.yastDesktopUtilitiesLabel.click();
+        await this.gnomeDesktopBasicLabel.click();
+    }
+
+    async deSelectPatterns() {
+        await this.enhancedBaseSystemLabel.click();
+    }
+    
+    async back() {
+        await this.backButton.click();
+    }
+}

--- a/tests/select-patterns.spec.ts
+++ b/tests/select-patterns.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { IndexActor } from "../actors/index-actor";
+import { UserActor } from "../actors/user-actor";
+import { MainPage } from '../pages/main-page';
+import { ProductSelectionOpensusePage } from '../pages/product-selection-opensuse-page';
+import { PatternsPage } from '../pages/patterns-page';
+import { InstallActor } from '../actors/install-actor';
+
+const minute = 60 * 1000;
+test.describe('The main page', () => {
+    test.beforeEach(async ({ page }) => {
+        const productSelectionOpensusePage = new ProductSelectionOpensusePage(page);
+        const mainPage = new MainPage(page);
+        const indexActor = new IndexActor(page, mainPage, productSelectionOpensusePage);
+        indexActor.goto();
+        indexActor.handleProductSelectionIfAny();
+    });
+
+    test('Select patterns', async ({ page }) => {
+        const mainPage = new MainPage(page);
+        await mainPage.expectInstallationSize();
+        await test.step("Select patterns", async () => {
+            const patternsPage = new PatternsPage(page);
+
+            await mainPage.accessSoftware();
+            await patternsPage.selectPatterns();
+            await patternsPage.deSelectPatterns();
+            await patternsPage.back();
+        });
+
+        await test.step("set mandatory user and root password", async () => {
+            await mainPage.accessUsers();
+            await (new UserActor(page)).handleUser();
+        });
+
+        //Installation
+        await test.step("Run installation", async () => {
+            test.setTimeout(30 * minute);
+            const installActor = new InstallActor(page, mainPage);
+            await installActor.handleInstallation();
+        })
+    });
+});


### PR DESCRIPTION
See https://progress.opensuse.org/issues/137369
And https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18097

Very basic test (only installs yast2_desktop pattern) if we want something more complex maybe we could find a way to import a pattern list from openqa.

VRs currently not working https://openqa.opensuse.org/tests/overview?version=agama-4.0-staging&build=JRivrain%2Fos-autoinst-distri-opensuse%2318097&distri=alp