### PR TITLE
Fix agam storage page timeout issue

### DIFF
--- a/tests/add-home-file-system.spec.ts
+++ b/tests/add-home-file-system.spec.ts
@@ -19,7 +19,6 @@ test.describe('The main page', () => {
 
     test('Add /home file system', async ({ page }) => {
         const mainPage = new MainPage(page);
-        await mainPage.expectInstallationSize();
         await test.step("Start to add home file system", async () => {
             await mainPage.accessStorage();
 

--- a/tests/encrypted_lvm.spec.ts
+++ b/tests/encrypted_lvm.spec.ts
@@ -19,7 +19,6 @@ test.describe('The main page', () => {
 
     test('Installation test with encrypted lvm file system', async ({ page }) => {
         const mainPage = new MainPage(page);
-        await mainPage.expectInstallationSize();
         await test.step("set encrypted lvm file system", async () => {
             await mainPage.accessStorage();
 

--- a/tests/full-disk-encryption.spec.ts
+++ b/tests/full-disk-encryption.spec.ts
@@ -19,7 +19,6 @@ test.describe('The main page', () => {
 
     test('Full-disk encryption', async ({ page }) => {
         const mainPage = new MainPage(page);
-        await mainPage.expectInstallationSize();
         await test.step("Set for Full-disk encryption", async () => {
             await mainPage.accessStorage();
 

--- a/tests/lvm.spec.ts
+++ b/tests/lvm.spec.ts
@@ -18,7 +18,6 @@ test.describe('The main page', () => {
 
     test("Use logical volume management (LVM) as storage device for installation", async ({ page }) => {
         const mainPage = new MainPage(page);
-        await mainPage.expectInstallationSize();
         await test.step("Set LVM and Users", async () => {
             await mainPage.accessStorage();
 

--- a/tests/select-install-device.spec.ts
+++ b/tests/select-install-device.spec.ts
@@ -19,7 +19,6 @@ test.describe('The main page', () => {
 
     test('Installation on second available storage device', async ({ page }) => {
         const mainPage = new MainPage(page);
-        await mainPage.expectInstallationSize();
         await test.step("select second available device for installation", async () => {
             const storagePage = new StoragePage(page);
             const installationDevice = new InstallationDevicePage(page);


### PR DESCRIPTION
Do not wait the calculation size ready on main page seams suitable the current build to fix the agama storage page timeout issue.
Related ticket: https://progress.opensuse.org/issues/138977
VRs:
aarch64: 
https://openqa.opensuse.org/tests/3696013#
https://openqa.opensuse.org/tests/3696024#
https://openqa.opensuse.org/tests/3696015#
https://openqa.opensuse.org/tests/3696016#
https://openqa.opensuse.org/tests/3696017#
x86_64:
https://openqa.opensuse.org/tests/3696018#
https://openqa.opensuse.org/tests/3696019#