### PR TITLE
[POC] Handle multiple products

### DIFF
--- a/pages/alp/README
+++ b/pages/alp/README
@@ -1,0 +1,1 @@
+Pages here are specific to ALP. Files from the parent directory are for Tumbleweed (factory first).

--- a/pages/alp/patterns-page.ts
+++ b/pages/alp/patterns-page.ts
@@ -1,0 +1,35 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+export class PatternsPage {
+    readonly page: Page;
+    readonly ldapclientLabel: Locator;
+    readonly selinuxSupport: Locator;
+    readonly backButton: Locator;
+
+    constructor(page: Page) {
+        this.page = page;
+        this.ldapclientLabel = page.getByText('LDAP Client', { exact: true });
+        this.selinuxSupport = page.getByText('SELinux Support', { exact: true });
+        this.backButton = page.getByRole('button', { name: 'Back' });
+    }
+
+    async selectPatterns() {
+        try { //try to workaround the page never really loading...
+            await expect(this.ldapclientLabel).toBeVisible({ timeout: 20000 });
+        } catch (error) {
+            console.error("LDAP client label was not visible within the timeout. Refreshing the page.");
+            await this.page.reload(); 
+            await expect(this.ldapclientLabel).toBeVisible({ timeout: 20000 });
+        }
+        
+        await this.ldapclientLabel.click();
+    }
+
+    async deSelectPatterns() {
+        await this.selinuxSupport.click();
+    }
+    
+    async back() {
+        await this.backButton.click();
+    }
+}

--- a/pages/main-page.ts
+++ b/pages/main-page.ts
@@ -2,6 +2,7 @@ import { expect, type Locator, type Page } from '@playwright/test';
 
 export class MainPage {
     readonly page: Page;
+    readonly accessSoftwareLink: Locator;
     readonly accessStorageLink: Locator;
     readonly accessUsersLink: Locator;
     readonly installButton: Locator;
@@ -10,11 +11,16 @@ export class MainPage {
 
     constructor(page: Page) {
         this.page = page;
+        this.accessSoftwareLink = page.getByRole('link', { name: 'Software' });
         this.accessStorageLink = page.getByRole('link', { name: 'Storage' });
         this.accessUsersLink = page.getByRole('link', { name: 'Users' });
         this.installButton = page.getByRole("button", { name: "Install", exact: true });
         this.installationSize = page.getByText("Installation will take");
         this.noUserDefined = page.getByText('No user defined yet');
+    }
+
+    async accessSoftware() {
+        await this.accessSoftwareLink.click();
     }
 
     async accessStorage() {

--- a/pages/patterns-page.ts
+++ b/pages/patterns-page.ts
@@ -1,0 +1,31 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+export class PatternsPage {
+    readonly page: Page;
+    readonly yastDesktopUtilitiesLabel: Locator;
+    readonly gnomeDesktopBasicLabel: Locator;
+    readonly enhancedBaseSystemLabel: Locator;
+    readonly backButton: Locator;
+
+    constructor(page: Page) {
+        this.page = page;
+        this.yastDesktopUtilitiesLabel = page.getByText('YaST Desktop Utilities');
+        this.gnomeDesktopBasicLabel = page.getByText('GNOME Desktop Environment (Basic)');
+        this.enhancedBaseSystemLabel = page.getByText('Enhanced Base System');
+        this.backButton = page.getByRole('button', { name: 'Back' });
+    }
+
+    async selectPatterns() {
+        await expect(this.yastDesktopUtilitiesLabel).toBeVisible({ timeout: 30000 });
+        await this.yastDesktopUtilitiesLabel.click();
+        await this.gnomeDesktopBasicLabel.click();
+    }
+
+    async deSelectPatterns() {
+        await this.enhancedBaseSystemLabel.click();
+    }
+    
+    async back() {
+        await this.backButton.click();
+    }
+}

--- a/tests/alp/README
+++ b/tests/alp/README
@@ -1,0 +1,1 @@
+Tests here here are specific to ALP. Files from the parent directory are for Tumbleweed (factory first).

--- a/tests/alp/select-patterns.spec.ts
+++ b/tests/alp/select-patterns.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { IndexActor } from "../../actors/index-actor";
+import { UserActor } from "../../actors/user-actor";
+import { MainPage } from '../../pages/main-page';
+import { ProductSelectionOpensusePage } from '../../pages/product-selection-opensuse-page';
+import { PatternsPage } from '../../pages/alp/patterns-page';
+import { InstallActor } from '../../actors/install-actor';
+
+const minute = 60 * 1000;
+test.describe('The main page', () => {
+    test.beforeEach(async ({ page }) => {
+        const productSelectionOpensusePage = new ProductSelectionOpensusePage(page);
+        const mainPage = new MainPage(page);
+        const indexActor = new IndexActor(page, mainPage, productSelectionOpensusePage);
+        indexActor.goto();
+        indexActor.handleProductSelectionIfAny();
+    });
+
+    test('Select patterns', async ({ page }) => {
+        const mainPage = new MainPage(page);
+        await mainPage.expectInstallationSize();
+        await test.step("Select patterns", async () => {
+            const patternsPage = new PatternsPage(page);
+
+            await mainPage.accessSoftware();
+            await patternsPage.selectPatterns();
+            await patternsPage.deSelectPatterns();
+            await patternsPage.back();
+        });
+
+        await test.step("set mandatory user and root password", async () => {
+            await mainPage.accessUsers();
+            await (new UserActor(page)).handleUser();
+        });
+
+        //Installation
+        await test.step("Run installation", async () => {
+            test.setTimeout(30 * minute);
+            const installActor = new InstallActor(page, mainPage);
+            await installActor.handleInstallation();
+        })
+    });
+});

--- a/tests/select-patterns.spec.ts
+++ b/tests/select-patterns.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { IndexActor } from "../actors/index-actor";
+import { UserActor } from "../actors/user-actor";
+import { MainPage } from '../pages/main-page';
+import { ProductSelectionOpensusePage } from '../pages/product-selection-opensuse-page';
+import { PatternsPage } from '../pages/patterns-page';
+import { InstallActor } from '../actors/install-actor';
+
+const minute = 60 * 1000;
+test.describe('The main page', () => {
+    test.beforeEach(async ({ page }) => {
+        const productSelectionOpensusePage = new ProductSelectionOpensusePage(page);
+        const mainPage = new MainPage(page);
+        const indexActor = new IndexActor(page, mainPage, productSelectionOpensusePage);
+        indexActor.goto();
+        indexActor.handleProductSelectionIfAny();
+    });
+
+    test('Select patterns', async ({ page }) => {
+        const mainPage = new MainPage(page);
+        await mainPage.expectInstallationSize();
+        await test.step("Select patterns", async () => {
+            const patternsPage = new PatternsPage(page);
+
+            await mainPage.accessSoftware();
+            await patternsPage.selectPatterns();
+            await patternsPage.deSelectPatterns();
+            await patternsPage.back();
+        });
+
+        await test.step("set mandatory user and root password", async () => {
+            await mainPage.accessUsers();
+            await (new UserActor(page)).handleUser();
+        });
+
+        //Installation
+        await test.step("Run installation", async () => {
+            test.setTimeout(30 * minute);
+            const installActor = new InstallActor(page, mainPage);
+            await installActor.handleInstallation();
+        })
+    });
+});


### PR DESCRIPTION
Soon or late, we will need to handle multiple products, we need to set-up a simple and strong architecture to avoid spaghetti code. This is an attempt at that, but keep in mind I'm not a developer and I know pretty much nothing about Typescript, so... not great so far, I would rather like to have the classes in alp/ directories to use files from parent directory as base class, or even something better that I did not figure out yet. This is inspired by [Distribution pattern in os-autoinst-distri-opensuse](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/ui-framework-documentation.md#definition-of-the-product-to-be-tested).
PR based on https://github.com/jknphy/e2e-agama-playwright/pull/26

VR https://openqa.opensuse.org/tests/3700837# fails with some timeout issue, but "works" otherwise.